### PR TITLE
fix(auth): authorize via access_groups (/EEG_ADMIN) not realm roles

### DIFF
--- a/api/eegController.go
+++ b/api/eegController.go
@@ -51,7 +51,7 @@ func (h *EegHandler) getEEG() middleware.JWTHandlerFunc {
 
 		var eeg *model.Eeg
 		var err error
-		if claims.RealmAccess.HasRole("admin") {
+		if claims.AccessGroups.IsAdmin() {
 			eeg, err = h.db.GetEegById(r.Context(), tenant)
 		} else {
 			eeg, err = h.db.GetEegByIdForUser(r.Context(), tenant)

--- a/api/middleware/tokenVerifier.go
+++ b/api/middleware/tokenVerifier.go
@@ -47,23 +47,23 @@ func (eve *VerifyError) Error() string {
 	return fmt.Sprintf("status %d: err %v", eve.StatusCode, eve.Err)
 }
 
-//func (ag AccessGroups) IsAdmin() bool {
-//	for _, s := range ag {
-//		if s == "/EEG_ADMIN" {
-//			return true
-//		}
-//	}
-//	return false
-//}
-//
-//func (ag AccessGroups) IsUser() bool {
-//	for _, s := range ag {
-//		if s == "/EEG_USER" {
-//			return true
-//		}
-//	}
-//	return false
-//}
+func (ag AccessGroups) IsAdmin() bool {
+	for _, s := range ag {
+		if s == "/EEG_ADMIN" {
+			return true
+		}
+	}
+	return false
+}
+
+func (ag AccessGroups) IsUser() bool {
+	for _, s := range ag {
+		if s == "/EEG_USER" {
+			return true
+		}
+	}
+	return false
+}
 
 // verifyAndExtractClaims tries the test-hook VerifyTokenClaims (if present) and
 // falls back to the actual OIDC verifier otherwise. It always returns a populated
@@ -179,9 +179,9 @@ func ConditionProtect(admin JWTHandlerFunc, user JWTHandlerFunc) http.HandlerFun
 		}
 
 		claims.Tenants = toUpper(claims.Tenants)
-		if hasRole(claims.RealmAccess.Roles, "admin") {
+		if claims.AccessGroups.IsAdmin() {
 			admin(w, r, claims, strings.ToUpper(tenant))
-		} else if hasRole(claims.RealmAccess.Roles, "user") {
+		} else if claims.AccessGroups.IsUser() {
 			user(w, r, claims, strings.ToUpper(tenant))
 		} else {
 			w.WriteHeader(http.StatusUnauthorized)
@@ -265,11 +265,11 @@ func verifyRequest(handler JWTHandlerFunc) func(w http.ResponseWriter, r *http.R
 			return
 		}
 
-		if hasRole(claims.RealmAccess.Roles, "admin") {
+		if claims.AccessGroups.IsAdmin() {
 			claims.Tenants = toUpper(claims.Tenants)
 			handler(w, r, claims, strings.ToUpper(tenant))
 		} else {
-			logrus.WithField("tenant", tenant).Warnf("Unauthorized access with tenant %s - Request has no role admin", tenant)
+			logrus.WithField("tenant", tenant).Warnf("Unauthorized access with tenant %s - Request has no admin access group", tenant)
 			w.WriteHeader(http.StatusUnauthorized)
 		}
 	}

--- a/api/participantController.go
+++ b/api/participantController.go
@@ -38,7 +38,7 @@ func NewParticipantHandler(db database.Database) *ParticipantHandler {
 
 func (h *ParticipantHandler) fetchParticipantAll() middleware.JWTHandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request, claims *middleware.PlatformClaims, tenant string) {
-		if claims.RealmAccess.HasRole("admin") {
+		if claims.AccessGroups.IsAdmin() {
 			participant, err := h.db.GetParticipants(r.Context(), tenant)
 			if err != nil {
 				log.WithField("tenant", tenant).WithError(err).Error("failed to fetch participant.")


### PR DESCRIPTION
Restores prod-compatible authz. de51a99 switched admin/user gates from `AccessGroups.IsAdmin()/IsUser()` (/EEG_ADMIN, /EEG_USER) to `RealmAccess.HasRole("admin"/"user")`. Prod keycloak grants admin via the **/EEG_ADMIN access group** (tokens have realm roles Manager/superuser + access_groups, no "admin" realm role) → v1.0.0 returned 401 "no role admin" for all admin requests. This reverts only the authz part of de51a99 (OIDC, superuser tenant-bypass, time fix untouched). Verified: builds, all 4 gates consistent on access_groups. Needs dev test with prod-shaped tokens before prod.