### PR TITLE
fix(notifications): store notification date in UTC (not local wall-clock)

### DIFF
--- a/database/notificationDao.go
+++ b/database/notificationDao.go
@@ -166,7 +166,12 @@ func createNotification(db *sqlx.DB, tenant, notification string,
 	msgType model.NotificationType, process model.NotificationProcess, role string) error {
 	stmt, _, err := pgDialect.Insert("base.notification").
 		Rows(
-			goqu.Record{"tenant": tenant, "notification": notification, "type": msgType, "role": role, "process": process},
+			// date explizit als UTC setzen statt dem Spalten-Default `now()`: die Spalte ist
+			// `timestamp without time zone`; `now()` schreibt lokale Wanduhrzeit (CEST), die als
+			// `...Z` serialisiert wird → Frontend rechnet +Offset doppelt. `now() at time zone 'utc'`
+			// liefert die UTC-Wanduhrzeit → korrekter Instant.
+			goqu.Record{"tenant": tenant, "notification": notification, "type": msgType, "role": role, "process": process,
+				"date": goqu.L("(now() AT TIME ZONE 'utc')")},
 		).
 		ToSQL()
 	if err != nil {


### PR DESCRIPTION
## Symptom
Messages/Notifications zeigen die Zeit **+2h zu spät** (Aktion 19:41 CEST → angezeigt als 21:41, mit 12h-Format als „9:41"). Roh aus der API: `"date":"2026-06-28T19:41:18.070854Z"` — das ist die **lokale** Zeit, fälschlich mit `Z` (UTC) markiert.

## Ursache
`base.notification.date` ist `timestamp without time zone DEFAULT (now())`. `createNotification` (database/notificationDao.go) ließ die Spalte weg → der Default `now()` schreibt die **lokale Wanduhrzeit** (Server `TZ=Europe/Berlin`). `lib/pq` liest `timestamp without time zone` als UTC-Location zurück → `json.Marshal` → `...T19:41:18Z`. Das Frontend (`moment(date)`) rechnet die +2h dann nochmal drauf.

## Fix
`date` explizit als **`now() AT TIME ZONE 'utc'`** setzen (überschreibt den lokalen Default) → gespeichert wird die UTC-Wanduhrzeit (17:41) → serialisiert `...T17:41:18Z` → Frontend rendert korrekt 19:41 CEST.

Kombiniert mit dem Frontend-PR ([eegfaktura-web#56](https://github.com/eegfaktura/eegfaktura-web/pull/56), `h`→`HH` 24h-Format) ergibt das die korrekte Anzeige.

## Hinweis
Behebt nur **neue** Zeilen. Bestehende Zeilen sind um den historischen lokalen Offset (+1h/+2h je DST) verschoben — optionaler einmaliger Backfill (Operator-Entscheid, nicht blind ausführen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)