### PR TITLE
docs: translate CHANGELOG.md to English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,25 @@
 # Changelog
 
-Alle nennenswerten Änderungen an **eegfaktura-backend (Go REST/GraphQL-API)** werden hier dokumentiert.
+All notable changes to **eegfaktura-backend (Go REST/GraphQL API)** are documented here.
 
-Das Format orientiert sich an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/),
-die Versionierung an den Deployment-Release-Tags. Detail-Diffs bleiben im `git log`;
-dieser Changelog hebt die für Überblick und Betrieb relevanten Änderungen hervor.
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and
+versioning follows the deployment release tags. Detailed diffs stay in the `git log`;
+this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
 ## [1.0.0] – 2026-06-28
 
-Erster vollständig aus öffentlichem Quellcode gebauter Produktiv-Release
-(einheitlicher Source-Build-Cutover der eegfaktura-Suite).
+First production release built entirely from public source (unified
+source-build cutover of the eegfaktura suite).
 
 ### Fixed
-- Benachrichtigungen: `notification.date` wird in UTC gespeichert statt in lokaler
-  Server-Wanduhrzeit; behebt eine Verschiebung um den TZ-Offset in der Anzeige. (#6)
-- Auth: Autorisierung über `access_groups` (`/EEG_ADMIN`, `/EEG_USER`) statt über
-  Realm-Rollen. (#5)
+- Notifications: `notification.date` is stored in UTC instead of the server's local
+  wall-clock time; fixes a TZ-offset shift in the displayed time. (#6)
+- Auth: authorize via `access_groups` (`/EEG_ADMIN`, `/EEG_USER`) instead of realm
+  roles. (#5)
 
 ### Changed
-- CI: self-building Dockerfile aus frischem Clone (Stage-1 Source-Build); Push in den
-  Development-Tier der Registry mit Auto-Rollout-Bridge (dispatch-deploy). (#2, #3)
-- README mit Service-Überblick und Tech-Stack ergänzt. (#4)
+- CI: self-building Dockerfile from a fresh clone (stage-1 source build); push to the
+  registry's development tier with an auto-rollout bridge (dispatch-deploy). (#2, #3)
+- Added README with service overview and tech stack. (#4)


### PR DESCRIPTION
Translates the recently added CHANGELOG.md to English for consistency with the READMEs, the org profile and eegfaktura-docs. Content unchanged.