### PR TITLE
fix(eda): CM_REV_SP-Ablehnung crasht das Backend (nil-pointer poison message)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,30 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.2] – 2026-06-29
+
+### Fixed
+- EDA Consent Management (`CM_REV_SP`): a rejection (`ABLEHNUNG_CCMS`) arrives
+  without a `<meter>` element, which dereferenced a nil pointer and crashed the
+  whole backend; the MQTT broker then crash-looped (QoS-1 redelivery) for every
+  tenant. The metering point and reason codes are now read from `responseData`,
+  the rejection is recorded as a notification, and the data release is kept
+  active (the metering point is no longer revoked on a rejection). Additionally,
+  any panic inside an MQTT protocol handler is now recovered so a single message
+  can never take down the process. (#9)
+
+## [1.0.1] – 2026-06-28
+
+### Fixed
+- Notifications: `notification.date` is stored in UTC instead of the server's local
+  wall-clock time; fixes a TZ-offset shift in the displayed time. (#6)
+
 ## [1.0.0] – 2026-06-28
 
 First production release built entirely from public source (unified
 source-build cutover of the eegfaktura suite).
 
 ### Fixed
-- Notifications: `notification.date` is stored in UTC instead of the server's local
-  wall-clock time; fixes a TZ-offset shift in the displayed time. (#6)
 - Auth: authorize via `access_groups` (`/EEG_ADMIN`, `/EEG_USER`) instead of realm
   roles. (#5)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ this changelog highlights the changes relevant for overview and operations.
   the rejection is recorded as a notification, and the data release is kept
   active (the metering point is no longer revoked on a rejection). Additionally,
   any panic inside an MQTT protocol handler is now recovered so a single message
-  can never take down the process. (#9)
+  can never take down the process. (#10)
 
 ## [1.0.1] – 2026-06-28
 

--- a/eda/edaHelpers.go
+++ b/eda/edaHelpers.go
@@ -60,13 +60,31 @@ func extractResponseCodeAndMeteringPointV2(ebmsMessage *model.EbmsMessage) ([]re
 
 	switch ebmsMessage.MessageCode {
 	case model.EBMS_AUFHEBUNG_CCMS, model.EBMS_ABLEHNUNG_CCMS:
-		codes = append(codes, 99)
-		response = []responseCodesPerMeter{{
-			meter:      ebmsMessage.Meter.MeteringPoint,
-			codes:      []int16{99},
-			consentEnd: civil.DateOf(time.UnixMilli(ebmsMessage.ConsentEnd)),
-			consentId:  consentId(ebmsMessage.Meter.ConsentID),
-		}}
+		if ebmsMessage.Meter != nil {
+			codes = append(codes, 99)
+			response = []responseCodesPerMeter{{
+				meter:      ebmsMessage.Meter.MeteringPoint,
+				codes:      []int16{99},
+				consentEnd: civil.DateOf(time.UnixMilli(ebmsMessage.ConsentEnd)),
+				consentId:  consentId(ebmsMessage.Meter.ConsentID),
+			}}
+		} else {
+			// A rejection (ABLEHNUNG_CCMS) carries no <meter> element; the metering
+			// point and reason codes arrive via ResponseData instead. Build from
+			// there so the rejection can still be recorded (and to avoid a
+			// nil-pointer dereference on ebmsMessage.Meter).
+			for _, rd := range ebmsMessage.ResponseData {
+				if len(rd.ResponseCode) > 0 {
+					codes = append(codes, rd.ResponseCode...)
+				}
+				response = append(response, responseCodesPerMeter{
+					meter:      rd.MeteringPoint,
+					codes:      rd.ResponseCode,
+					consentEnd: civil.DateOf(time.UnixMilli(rd.ConsentEnd)),
+					consentId:  consentId(rd.ConsentId),
+				})
+			}
+		}
 	default:
 		for _, rd := range ebmsMessage.ResponseData {
 			if len(rd.ResponseCode) > 0 {

--- a/eda/edaSubscription.go
+++ b/eda/edaSubscription.go
@@ -381,10 +381,15 @@ func protocolCmRevImpHandler(ctx context.Context, msg model.SubscribeMessage) {
 
 	var eeg *model.Eeg
 	switch msg.MessageCode {
-	case model.EBMS_AUFHEBUNG_CCMS, model.EBMS_ABLEHNUNG_CCMS:
+	case model.EBMS_AUFHEBUNG_CCMS:
 		eeg, err = db.GetEegByEcId(ctx, msg.Payload.EcId)
 		if err != nil {
 			logrus.WithField("tenant", msg.Tenant).Errorf("can not fetch eeg with message -> %+v", msg.Payload)
+			return
+		}
+
+		if len(meters) == 0 {
+			logrus.WithField("tenant", msg.Tenant).Errorf("no metering point in %s message -> %+v", msg.MessageCode, msg.Payload)
 			return
 		}
 
@@ -393,7 +398,23 @@ func protocolCmRevImpHandler(ctx context.Context, msg model.SubscribeMessage) {
 			return
 		}
 
+	case model.EBMS_ABLEHNUNG_CCMS:
+		// The grid operator rejected the termination of the data-release consent
+		// (Customer Consent Management), so the data release stays active and the
+		// metering point must NOT be revoked. Only fetch the EEG so the rejection
+		// is persisted as a notification (see below) and stays visible to the user.
+		eeg, err = db.GetEegByEcId(ctx, msg.Payload.EcId)
+		if err != nil {
+			logrus.WithField("tenant", msg.Tenant).Errorf("can not fetch eeg with message -> %+v", msg.Payload)
+			return
+		}
+
 	case model.EBMS_AUFHEBUNG_CCMC, model.EBMS_AUFHEBUNG_CCMI:
+
+		if len(meters) == 0 {
+			logrus.WithField("tenant", msg.Tenant).Errorf("no metering point in %s message -> %+v", msg.MessageCode, msg.Payload)
+			return
+		}
 
 		var tenant *string
 		if tenant, err = db.MeteringPointRevokeByConsentId(ctx, meters[0].consentId, meters[0].meter, meters[0].consentEnd); err != nil {

--- a/mqtt/messageBroker.go
+++ b/mqtt/messageBroker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -207,6 +208,17 @@ func (m *MessageBroker) Stop() {
 }
 
 func (m *MessageBroker) received(inbound InboundMessage) {
+
+	// A panic inside a protocol handler must not kill the whole broker goroutine
+	// (and with it the process): one malformed/unexpected message would otherwise
+	// take down every tenant. Recover, log it, and drop just this message.
+	defer func() {
+		if r := recover(); r != nil {
+			log.WithField("tenant", inbound.tenant).
+				WithField("protocol", inbound.protocol).
+				Errorf("recovered from panic while handling MQTT message: %v\n%s", r, debug.Stack())
+		}
+	}()
 
 	if inbound.protocol == model.CR_MSG_ORG {
 		return


### PR DESCRIPTION
## Problem (Prod-Incident 2026-06-29)

Der Backend-Pod startete mehrfach neu. `--previous`-Logs zeigen: eine eingehende EDA-Nachricht **`CM_REV_SP` Code `ABLEHNUNG_CCMS`** (Ablehnung einer Datenfreigabe-Beendigung durch den Netzbetreiber) führt zu

```
panic: nil pointer dereference [SIGSEGV]
extractResponseCodeAndMeteringPointV2  eda/edaHelpers.go:68
protocolCmRevImpHandler                eda/edaSubscription.go:374
```

Die Ablehnung kommt **ohne `<meter>`-Element** → `ebmsMessage.Meter` ist `nil`, der Code dereferenziert es aber. Der Panic verlässt die MQTT-Receive-Goroutine und **killt den gesamten Backend-Prozess**; per QoS-1-Redelivery entsteht ein **Crash-Loop für alle Tenants** (Poison-Message). Das ist der Downstream-Grund, warum abgelehnte Abmeldungen nie verarbeitet werden (vgl. Support-Fall 23.06.).

## Domäne (CM_REV_SP = Customer Consent Management)

`cm_rev_sp` = vom **Service Provider/der EEG** initiierte Beendigung der **Datenfreigabe** eines Zählpunkts. Wir senden `AUFHEBUNG_CCMS` (Anfrage). Der Netzbetreiber antwortet — `ABLEHNUNG_CCMS` = **abgelehnt** → Datenfreigabe bleibt → ZP darf **nicht** abgemeldet werden. (Quelle: ebUtilities Prozess 297 / CM_REV_SP.)

## Fix

1. **`extractResponseCodeAndMeteringPointV2`**: bei `Meter == nil` (Ablehnung) Zählpunkt + Grund-Codes aus `responseData` lesen statt aus `Meter` → kein nil-Deref.
2. **`protocolCmRevImpHandler`**: `ABLEHNUNG_CCMS` aus dem `AUFHEBUNG_CCMS`-Case herausgelöst → **kein** `MeteringPointRevoke`; nur Notification (über den bestehenden Block am Funktionsende), damit der User die Ablehnung mit Grund sieht. Plus `len(meters)`-Guards vor `meters[0]` in den Revoke-Cases.
3. **`messageBroker.received`**: `recover()` → ein Panic in einem Handler verwirft nur die eine Nachricht statt den ganzen Broker/Prozess zu killen (Resilienz gegen künftige Poison-Messages).

## Verifikation

- `go build ./...` grün (nach Codegen `make protoc` + `go generate`). `gofmt` clean.
- Hinweis: das `eda`-Test-Package kompiliert schon **vor** diesem PR nicht (`edaSubscription_test.go:511` ruft `db.FindMeteringByStatus` mit veralteter Signatur ohne `ctx`); CI baut nur das Docker-Image und führt keine `go test` aus. Eine Regressions-Test-Ergänzung ist daher in einem separaten PR sinnvoll (zusammen mit dem Test-Fix).

## CHANGELOG-Korrektur

Der UTC-Notification-Fix (#6) wurde fälschlich unter `[1.0.0]` geführt, lief aber als **v1.0.1** (Image-Revision `72b6b68`). Fehlenden `[1.0.1]`-Eintrag nachgetragen; dieser Fix als **[1.0.2]**.