### PR TITLE
fix(db): prepared statements in getEegById/getEegByEcId (Snyk SQLi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Fixed
+- Security: `getEegById`/`getEegByEcId` now build their queries with goqu
+  prepared statements (bind parameters) instead of interpolated SQL, removing
+  the Snyk Code SQL-injection findings on `database/eegDao.go`. (Snyk `go/Sqli`)
+
 ## [1.0.2] – 2026-06-29
 
 ### Fixed

--- a/database/eegDao.go
+++ b/database/eegDao.go
@@ -83,12 +83,12 @@ func (db *sqlDatabase) UpdateOnlineState(ctx context.Context, tenant string, onl
 func getEegById(ctx context.Context, tx *sqlx.DB, tenant string) (*model.Eeg, error) {
 
 	var eeg model.Eeg
-	stmt, _, err := pgDialect.From(TABLE_EEG).Select(&eeg).Where(goqu.C("tenant").Eq(tenant)).ToSQL()
+	stmt, args, err := pgDialect.From(TABLE_EEG).Select(&eeg).Where(goqu.C("tenant").Eq(tenant)).Prepared(true).ToSQL()
 	if err != nil {
 		return nil, model.ErrGetEeg(err)
 	}
 
-	err = tx.GetContext(ctx, &eeg, stmt)
+	err = tx.GetContext(ctx, &eeg, stmt, args...)
 	if err != nil {
 		log.WithField("SQL", "SELECT").Errorf("Stmt: %s", stmt)
 		return nil, model.ErrGetEeg(err)
@@ -99,12 +99,12 @@ func getEegById(ctx context.Context, tx *sqlx.DB, tenant string) (*model.Eeg, er
 func getEegByEcId(ctx context.Context, tx *sqlx.DB, edId string) (*model.Eeg, error) {
 
 	var eeg model.Eeg
-	stmt, _, err := pgDialect.From(TABLE_EEG).Select(&eeg).Where(goqu.C("communityId").Eq(edId)).ToSQL()
+	stmt, args, err := pgDialect.From(TABLE_EEG).Select(&eeg).Where(goqu.C("communityId").Eq(edId)).Prepared(true).ToSQL()
 	if err != nil {
 		return nil, model.ErrGetEeg(err)
 	}
 
-	err = tx.GetContext(ctx, &eeg, stmt)
+	err = tx.GetContext(ctx, &eeg, stmt, args...)
 	if err != nil {
 		log.WithField("SQL", "SELECT").Errorf("Stmt: %s", stmt)
 		return nil, model.ErrGetEeg(err)


### PR DESCRIPTION
Behebt die zwei Snyk-Code-HIGH-Alerts `go/Sqli` auf `database/eegDao.go:91/107`.

Beide Funktionen bauten ihr SELECT via goqu `ToSQL()` (interpolierter SQL-String) und gaben den String ohne Bind-Args an `GetContext`. goqu escaped interpolierte Literale → reales Risiko gering, aber kein echtes Parametrisieren. Umstellung auf `.Prepared(true)` + `GetContext(..., args...)` → echte Bind-Parameter, Alert weg.

`go build ./database/` grün. (Das goqu-Non-Prepared-Muster wird auch andernorts genutzt — repo-weite Migration wäre ein separater Folge-PR.)