### PR TITLE
fix(db): register goqu postgres dialect so prepared queries emit $1 placeholders

### DIFF
--- a/database/databaseHelper.go
+++ b/database/databaseHelper.go
@@ -6,6 +6,12 @@ import (
 	"strings"
 
 	"github.com/doug-martin/goqu/v9"
+	// Register goqu's postgres dialect so goqu.Dialect("postgres") / goqu.New("postgres", …)
+	// resolve to the real postgres dialect. Without this blank import goqu silently falls back
+	// to the default dialect, which emits "?" placeholders in Prepared mode — lib/pq then fails
+	// with `pq: syntax error at or near ")"` (broke getEegById/getEegByEcId after #13 added
+	// .Prepared(true)).
+	_ "github.com/doug-martin/goqu/v9/dialect/postgres"
 	"gopkg.in/guregu/null.v4"
 )
 


### PR DESCRIPTION
## Symptom (Dev)
`eegfaktura-dev`: keine EEG lädt mehr — `GET /eeg` → `pq: syntax error at or near ")"`, UI „Keine aktive EEG geladen", Folgefehler `report` → `tenant is too long (UNDEFINED)`.

## Root Cause
`getEegById`/`getEegByEcId` nutzen `pgDialect = goqu.Dialect("postgres")`. Das goqu-**postgres-Dialekt-Paket war aber nie importiert** → goqu fällt **still auf den Default-Dialekt** zurück, der im **Prepared-Modus `?`-Platzhalter** erzeugt. lib/pq (Postgres) braucht `$1` → `syntax error at or near ")"`.

Latent bis **#13** (`af066e3`) `.Prepared(true)` ergänzte: vorher wurden Werte inline gerendert (kein Platzhalter), seitdem zählt der Dialekt-Platzhalterstil → Bug bricht auf.

## Fix
Blank-Import in `database/databaseHelper.go`:
```go
_ "github.com/doug-martin/goqu/v9/dialect/postgres"
```
Registriert den echten postgres-Dialekt für `goqu.Dialect("postgres")` **und** `goqu.New("postgres", …)` (meteringPointDao). Eine Zeile, kein go.mod-Change (goqu v9 ist bereits Dep).

## Verifikation
- goqu-Mechanismus isoliert geprüft: **mit** Import → `SELECT … WHERE ("tenant" = $1)` + args `[TE100200]`; ohne → `?`.
- `go build ./database/` (go 1.25) ✅.

## Scope
- **Prod nicht betroffen** (laufendes Prod-Backend ist vor #13). Relevant **vor** einem Prod-Cutover auf die #13-Linie.
- Verbessert nebenbei die SQLi-Härtung (Queries laufen jetzt echt parametrisiert statt Fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
