### PR TITLE
fix(security): bind json_to_recordset input instead of interpolating it (SQLi)

### DIFF
--- a/database/meteringPointDao.go
+++ b/database/meteringPointDao.go
@@ -795,7 +795,7 @@ func MeteringPointChangePartFactor(ctx context.Context, db *sqlx.DB, tenant stri
 	}
 
 	withClause := goqu.L(
-		fmt.Sprintf(`(SELECT * FROM json_to_recordset('%s') AS cols("meteringPoint" TEXT, direction TEXT, activation BIGINT, "partFact" INT))`, metersJson))
+		`(SELECT * FROM json_to_recordset(?::json) AS cols("meteringPoint" TEXT, direction TEXT, activation BIGINT, "partFact" INT))`, string(metersJson))
 	insertQuery := goqu.From(TABLE_METERINGPOINT, withClause.As("ma")).
 		Select(
 			goqu.C("metering_point_id"),


### PR DESCRIPTION
## Befund (Security-Review, pre-existing)
`MeteringPointChangePartFactor` ([database/meteringPointDao.go:797](../blob/master/database/meteringPointDao.go#L797)) baute eine CTE so:
```go
goqu.L(fmt.Sprintf(`(SELECT * FROM json_to_recordset('%s') AS cols(...))`, metersJson))
```
`json.Marshal` escaped **kein `'`** → ein `'` in einem Meter-Feld (`meteringPoint`) bricht aus dem SQL-String-Literal aus = **SQL-Injection**.

**Erreichbarkeit:** Über den REST-Controller kommen `meteringPoint`/`direction` aus der DB (geringeres Risiko), aber der **EDA-Pfad** ([eda/edaSubscription.go:502](../blob/master/eda/edaSubscription.go#L502)) speist `meters` aus **externen Marktnachrichten** → `meteringPoint` ist dort fremdbestimmt. Defense-in-depth: Interpolation gehört in jedem Fall weg.

## Fix
Wert als gebundenes `goqu.L`-Argument übergeben statt roh interpolieren:
```diff
- goqu.L(fmt.Sprintf(`(… json_to_recordset('%s') …)`, metersJson))
+ goqu.L(`(… json_to_recordset(?::json) …)`, string(metersJson))
```
goqu escaped/parametrisiert den Wert dann selbst.

## Verifikation (before/after, Payload `AT'); DROP TABLE base.metering_partition_factor;--`)
- **alt:** `… '[{"meteringPoint":"AT'); DROP TABLE …"}]' …` → Literal ausgebrochen, injizierbar
- **neu:** `… '[{"meteringPoint":"AT''); DROP TABLE …"}]'::json …` → `'` zu `''` escaped, eingeschlossen ✅
- `go build ./database/` (go 1.25) ✅

Einzeiler, kein neues Verhalten außer der Escaping/Cast. Gefunden im Security-Review von #23, separat gefixt wie besprochen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
