### PR TITLE
fix: admin inactive-date update never applied (wrong variable scan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+### Fixed
+- Admin master update: the `INACTIVESINCE` update never took effect because the
+  parsed inactive-since timestamp was scanned into the `activeSince` variable, so
+  `inactiveSince` stayed invalid and the handler returned 501. Scan it into
+  `inactiveSince` (also fixes the process-state → INACTIVE path). (#17)
+
 ## [1.0.3] – 2026-06-30
 
 ### Fixed

--- a/services/adminService.go
+++ b/services/adminService.go
@@ -34,7 +34,7 @@ func (r *AdminService) UpdateValue(ctx context.Context, request *protobuf.Update
 	if inactiveSinceValue, exists = request.Value["inactiveSince"]; exists {
 		timestamp, err := strconv.ParseInt(inactiveSinceValue, 10, 64)
 		if err == nil {
-			_ = activeSince.Scan(time.UnixMilli(timestamp))
+			_ = inactiveSince.Scan(time.UnixMilli(timestamp))
 		}
 	}
 


### PR DESCRIPTION
## Problem
Support team reported: in the admin tool the **active** date (Aktiv) of a metering point can be changed, but the **inactive** date (Inaktiv) cannot.

## Root cause
In `services/adminService.go` `UpdateValue`, the `inactiveSince` timestamp was scanned into the **`activeSince`** variable (copy-paste from the block above):

```go
if inactiveSinceValue, exists = request.Value["inactiveSince"]; exists {
    timestamp, err := strconv.ParseInt(inactiveSinceValue, 10, 64)
    if err == nil {
        _ = activeSince.Scan(time.UnixMilli(timestamp))   // ← should be inactiveSince
    }
}
```

So `inactiveSince.Valid` stayed `false`, and the `INACTIVESINCE` case tripped its `!inactiveSince.Valid` guard and returned **501**. The frontend and admin-backend paths are symmetric — the asymmetry was solely here.

Side effect: the `PROCESSSTATUS` → `INACTIVE` path also passed a nil `inactiveSince` (and a wrongly populated `activeSince`) to `UpdateProcessStatus`.

## Fix
Scan the inactive-since timestamp into `inactiveSince`.

## Verification
- `go build ./services/` + `go vet ./services/` clean (proto regenerated locally via `make protoc`; generated `.pb.go` not committed).
- Pure backend logic fix; no API/GUI surface change.