### PR TITLE
docs(changelog): release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ this changelog highlights the changes relevant for overview and operations.
 
 ## [Unreleased]
 
+## [1.0.4] – 2026-07-01
+
 ### Fixed
 - Admin master update: the `INACTIVESINCE` update never took effect because the
   parsed inactive-since timestamp was scanned into the `activeSince` variable, so


### PR DESCRIPTION
Stamps the `[Unreleased]` INACTIVESINCE fix (#17) as **[1.0.4] – 2026-07-01**, matching the deployed `:v1.0.4` image (digest `sha256:5fdf5a9…`, identical to dev-verified `sha-2349a62`).

Docs-only.